### PR TITLE
Update outliers.ranking function to use ward.D

### DIFF
--- a/R/OR.R
+++ b/R/OR.R
@@ -22,7 +22,7 @@ outliers.ranking <- function(data,test.data=NULL,
                              method='sizeDiff',
                              method.pars=NULL,
                              clus=list(dist='euclidean',alg='hclust',
-                               meth='ward'),
+                               meth='ward.D'),
                              power=1,
                              verb=F) {
 


### PR DESCRIPTION
In Or.R, the outliers.ranking function uses the method 'ward' for heirarichal clustering.

'ward' has been replaced by 'ward.D' (which I believe is identical to 'ward') and 'ward.D2' (which I think is intended to be an improvement)

Currently, the code returns warnings that 'ward' should be replaced.
